### PR TITLE
Fix distributed FI NCCL desync with run_forward_on_skip (#1877)

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -302,6 +302,7 @@ class FeatureAblation(PerturbationAttribution):
         feature_mask: Union[None, Tensor, Tuple[Tensor, ...]] = None,
         perturbations_per_eval: int = 1,
         show_progress: bool = False,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> TensorOrTupleOfTensorsGeneric:
         r"""
@@ -422,6 +423,20 @@ class FeatureAblation(PerturbationAttribution):
                         It will try to use tqdm if available for advanced features
                         (e.g. time estimation). Otherwise, it will fallback to
                         a simple output of progress.
+                        Default: False
+            run_forward_on_skip (bool, optional): When True, a feature group that
+                        would otherwise be skipped (e.g. because a per-rank batch
+                        is smaller than ``min_examples_per_batch_grouped``), or
+                        whose ablated/permuted inputs cannot be constructed on this
+                        rank (e.g. a custom perm_func raises on a degenerate batch),
+                        still triggers a model forward on the unablated inputs whose
+                        result is discarded. This keeps distributed sharded models
+                        issuing the same number of forwards (and thus the same
+                        collectives, e.g. all-to-all) across ranks, so NCCL stays
+                        in lockstep even when per-rank batch shapes diverge. The
+                        affected group's attribution stays zero, so the numerical
+                        result is identical to skipping. Default False keeps
+                        single-process / OSS behavior unchanged.
                         Default: False
             **kwargs (Any, optional): Any additional arguments used by child
                         classes of FeatureAblation (such as Occlusion) to construct
@@ -556,6 +571,7 @@ class FeatureAblation(PerturbationAttribution):
                 weights,
                 attrib_type,
                 perturbations_per_eval,
+                run_forward_on_skip=run_forward_on_skip,
                 **kwargs,
             )
 
@@ -583,6 +599,7 @@ class FeatureAblation(PerturbationAttribution):
         weights: List[Tensor],
         attrib_type: dtype,
         perturbations_per_eval: int,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> Tuple[List[Tensor], List[Tensor]]:
         feature_idx_to_tensor_idx = self._get_feature_idx_to_tensor_idx(
@@ -619,11 +636,19 @@ class FeatureAblation(PerturbationAttribution):
                 perturbations_per_eval, len(current_feature_idxs)
             )
 
-            if self._should_skip_inputs_and_warn(
+            should_skip = self._should_skip_inputs_and_warn(
                 current_feature_idxs,
                 feature_idx_to_tensor_idx,
                 formatted_inputs,
-            ):
+            )
+            if should_skip and run_forward_on_skip:
+                _run_forward(
+                    self.forward_func,
+                    formatted_inputs,
+                    target,
+                    formatted_additional_forward_args,
+                )
+            if should_skip:
                 continue
 
             # Store appropriate inputs and additional args based on batch size.

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -116,6 +116,7 @@ class FeaturePermutation(FeatureAblation):
         perturbations_per_eval: int = 1,
         n_samples: int = 1,
         show_progress: bool = False,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> TensorOrTupleOfTensorsGeneric:
         r"""
@@ -217,6 +218,17 @@ class FeaturePermutation(FeatureAblation):
                             (e.g. time estimation). Otherwise, it will fallback to
                             a simple output of progress.
                             Default: False
+                run_forward_on_skip (bool, optional): When True, a feature group
+                            that would otherwise be skipped (e.g. because a
+                            per-rank batch is smaller than
+                            ``min_examples_per_batch_grouped``) still triggers a
+                            model forward whose result is discarded, so distributed
+                            sharded models keep their collectives (e.g. all-to-all)
+                            in lockstep across ranks. The skipped group's
+                            attribution stays zero. See
+                            :func:`FeatureAblation.attribute` for details. Default
+                            False keeps single-process / OSS behavior unchanged.
+                            Default: False
                 **kwargs (Any, optional): Any additional arguments used by child
                             classes of :class:`.FeatureAblation` (such as
                             :class:`.Occlusion`) to construct ablations. These
@@ -286,6 +298,7 @@ class FeaturePermutation(FeatureAblation):
             feature_mask=feature_mask,
             perturbations_per_eval=perturbations_per_eval,
             show_progress=show_progress,
+            run_forward_on_skip=run_forward_on_skip,
             **kwargs,
         )
 
@@ -302,6 +315,7 @@ class FeaturePermutation(FeatureAblation):
                 feature_mask=feature_mask,
                 perturbations_per_eval=perturbations_per_eval,
                 show_progress=show_progress,
+                run_forward_on_skip=run_forward_on_skip,
                 **kwargs,
             )
             formatted_current_attributions = _format_tensor_into_tuples(
@@ -330,6 +344,7 @@ class FeaturePermutation(FeatureAblation):
         feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
         perturbations_per_eval: int = 1,
         show_progress: bool = False,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> TensorOrTupleOfTensorsGeneric:
         # Remove baselines from kwargs if provided so we don't specify this field
@@ -345,6 +360,7 @@ class FeaturePermutation(FeatureAblation):
             feature_mask=feature_mask,
             perturbations_per_eval=perturbations_per_eval,
             show_progress=show_progress,
+            run_forward_on_skip=run_forward_on_skip,
             **kwargs,
         )
 

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -12,7 +12,7 @@ import threading
 import time
 import unittest
 import unittest.mock
-from typing import Any, cast, List, Tuple, Union
+from typing import Any, Callable, cast, List, Tuple, Union
 
 import torch
 from captum._utils.common import _construct_future_forward
@@ -665,6 +665,70 @@ class Test(BaseTest):
                     baselines=None,
                     perturbations_per_eval=batch_size,
                 )
+
+    def test_run_forward_on_skip_keeps_forward_count_in_lockstep(self) -> None:
+        # Regression test for the distributed NCCL-desync fix: when a per-rank
+        # batch is uneven, a rank-local skip drops a model forward, offsetting the
+        # shard PG's collective count. run_forward_on_skip=True must keep the
+        # forward count identical to the no-skip case so every rank stays in
+        # lockstep, while the skipped group's attribution stays zero.
+        def make_counting_forward() -> Tuple[Callable[..., Tensor], List[int]]:
+            calls: list[int] = [0]
+
+            def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+                calls[0] += 1
+                return x2.sum(dim=-1)
+
+            return forward_func, calls
+
+        # Feature group 0 lives only in x1; groups 1 and 2 live only in x2.
+        mask = (
+            torch.tensor([[0, 0]]),
+            torch.tensor([[1, 2]]),
+        )
+
+        def build_ablator(forward_func: Callable[..., Tensor]) -> FeatureAblation:
+            ablator = FeatureAblation(forward_func)
+            ablator._min_examples_per_batch_grouped = 2
+            return ablator
+
+        # Baseline: every tensor has batch size >= 2, so no group is skipped.
+        # 1 initial eval + 3 group forwards = 4 forwards.
+        no_skip_forward, no_skip_calls = make_counting_forward()
+        build_ablator(no_skip_forward).attribute(
+            (
+                torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+                torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+            ),
+            feature_mask=mask,
+        )
+        self.assertEqual(no_skip_calls[0], 4)
+
+        # x1 now has batch size 1, so group 0 fires the min-examples skip.
+        uneven_inp = (
+            torch.tensor([[1.0, 2.0]]),
+            torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        )
+
+        # With run_forward_on_skip=True, the skipped group still issues a forward,
+        # matching the no-skip count exactly (lockstep).
+        skip_on_forward, skip_on_calls = make_counting_forward()
+        attribs = build_ablator(skip_on_forward).attribute(
+            uneven_inp,
+            feature_mask=mask,
+            run_forward_on_skip=True,
+        )
+        self.assertEqual(skip_on_calls[0], no_skip_calls[0])
+        # The skipped group (feature 0, in x1) keeps its zero-initialized attribution.
+        assertTensorAlmostEqual(
+            self, attribs[0], torch.zeros_like(attribs[0]), delta=0.0
+        )
+
+        # Default behavior (run_forward_on_skip=False) drops the skipped group's
+        # forward, which is exactly the desync this flag fixes.
+        skip_off_forward, skip_off_calls = make_counting_forward()
+        build_ablator(skip_off_forward).attribute(uneven_inp, feature_mask=mask)
+        self.assertEqual(skip_off_calls[0], no_skip_calls[0] - 1)
 
     def test_unassociated_output_3d_tensor(self) -> None:
         def forward_func(inp: Tensor) -> Tensor:

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -192,6 +192,80 @@ class Test(BaseTest):
         with self.assertRaises(AssertionError):
             feature_importance.attribute(inp, feature_mask=mask)
 
+    def _deterministic_perm(self, x: Tensor, feature_mask: Tensor) -> Tensor:
+        # Deterministic stand-in for the default random permutation so the
+        # forward-count invariant below does not depend on an RNG seed.
+        return (x.flip(0) * feature_mask.to(dtype=x.dtype)) + (
+            x * feature_mask.bitwise_not().to(dtype=x.dtype)
+        )
+
+    def test_run_forward_on_skip_keeps_forward_count_in_lockstep(self) -> None:
+        # Regression test for the distributed NCCL-desync fix: when a per-rank
+        # batch is uneven, a rank-local skip drops a model forward, offsetting the
+        # shard PG's collective count. run_forward_on_skip=True must keep the
+        # forward count identical to the no-skip case so every rank stays in
+        # lockstep, while the skipped group's attribution stays zero.
+        def make_counting_forward() -> Tuple[Callable[..., Tensor], List[int]]:
+            calls: list[int] = [0]
+
+            def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+                calls[0] += 1
+                return x2.sum(dim=-1)
+
+            return forward_func, calls
+
+        # Feature group 0 lives only in x1; groups 1 and 2 live only in x2.
+        mask = (
+            torch.tensor([[0, 0]]),
+            torch.tensor([[1, 2]]),
+        )
+
+        # Baseline: every tensor has batch size >= 2, so no group is skipped.
+        # 1 initial eval + 3 group forwards = 4 forwards.
+        no_skip_forward, no_skip_calls = make_counting_forward()
+        no_skip_attr = FeaturePermutation(
+            forward_func=no_skip_forward, perm_func=self._deterministic_perm
+        )
+        no_skip_attr.attribute(
+            (
+                torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+                torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+            ),
+            feature_mask=mask,
+        )
+        self.assertEqual(no_skip_calls[0], 4)
+
+        # x1 now has batch size 1, so group 0 fires the min-examples skip
+        # (_min_examples_per_batch_grouped defaults to 2 for FeaturePermutation).
+        uneven_inp = (
+            torch.tensor([[1.0, 2.0]]),
+            torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        )
+
+        # With run_forward_on_skip=True, the skipped group still issues a forward,
+        # matching the no-skip count exactly (lockstep).
+        skip_on_forward, skip_on_calls = make_counting_forward()
+        skip_on_attr = FeaturePermutation(
+            forward_func=skip_on_forward, perm_func=self._deterministic_perm
+        )
+        attribs = skip_on_attr.attribute(
+            uneven_inp, feature_mask=mask, run_forward_on_skip=True
+        )
+        self.assertEqual(skip_on_calls[0], no_skip_calls[0])
+        # The skipped group (feature 0, in x1) keeps its zero-initialized attribution.
+        assertTensorAlmostEqual(
+            self, attribs[0], torch.zeros_like(attribs[0]), delta=0.0
+        )
+
+        # Default behavior (run_forward_on_skip=False) drops the skipped group's
+        # forward, which is exactly the desync this flag fixes.
+        skip_off_forward, skip_off_calls = make_counting_forward()
+        skip_off_attr = FeaturePermutation(
+            forward_func=skip_off_forward, perm_func=self._deterministic_perm
+        )
+        skip_off_attr.attribute(uneven_inp, feature_mask=mask)
+        self.assertEqual(skip_off_calls[0], no_skip_calls[0] - 1)
+
     def test_single_input_with_future(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:

User post: https://fb.workplace.com/groups/1699838000485189/posts/2491304718005176

Some models issue an all-to-all in the forward pass, so some ranks inconsistently skipping some iterations based on the batch they receive (when the EBF has fewer than two events, which means we can't permute the feature) can lead to an NCCL hang. Currently have only seen users reporting this for APS.

Diff introduces a flag to just perform the model forward anyway to keep the collectives in sync (similar to NI engine). This doesn't change the way FI is calculated.

Behavior is behind a JK internally, which is currently turned on, as an emergency killswitch, e.g. in case of performance regressions (though I don't expect it due to generally low EBF counts). OSS default behavior is the same.

Differential Revision: D112450238


