### PR TITLE
Keep Occlusion masks on the input device

### DIFF
--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -392,7 +392,10 @@ class Occlusion(FeatureAblation):
 
                 if feature_idx_to_tensor_idx[feature_idx][0] != i:
                     tensor_mask.append(
-                        torch.zeros((1,) + tuple(input_tensor.shape[1:]))
+                        torch.zeros(
+                            (1,) + tuple(input_tensor.shape[1:]),
+                            device=input_tensor.device,
+                        )
                     )
                     continue
                 ablated_feature_num = feature_idx - accumulated_shift_count_prods[i]

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -223,6 +223,25 @@ class Test(BaseTest):
             sliding_window_shapes=((3,), (1,)),
         )
 
+    def test_multi_input_mask_placeholders_keep_input_device(self) -> None:
+        device = torch.device("meta")
+        inp1 = torch.empty((1, 3), device=device)
+        inp2 = torch.empty((1, 3), device=device)
+
+        def forward_func(input1: Tensor, input2: Tensor) -> Tensor:
+            return (input1 + input2).sum(dim=1)
+
+        attributions = Occlusion(forward_func).attribute(
+            (inp1, inp2),
+            sliding_window_shapes=((1,), (1,)),
+            perturbations_per_eval=2,
+        )
+
+        self.assertEqual(attributions[0].device, device)
+        self.assertEqual(attributions[1].device, device)
+        self.assertEqual(attributions[0].shape, inp1.shape)
+        self.assertEqual(attributions[1].shape, inp2.shape)
+
     def test_multi_input_ablation_with_baselines(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])


### PR DESCRIPTION
## Summary

- Keep Occlusion's placeholder masks on the same device as the corresponding input tensor.
- Add a regression test covering multi-input Occlusion with `perturbations_per_eval > 1`.

Fixes #1879.

## Why

When batching occlusions across multiple input tensors, Occlusion creates placeholder masks for tensors that are not ablated by the current feature. Those placeholder masks were created on CPU, while the real occlusion masks follow the input tensor device. On CUDA inputs this can fail during `torch.stack` with a device mismatch.

## Tests

- `D:\Dev\Miniconda3\python.exe -m pytest tests/attr/test_occlusion.py::Test::test_multi_input_mask_placeholders_keep_input_device -q -p no:cacheprovider`
- `D:\Dev\Miniconda3\python.exe -m pytest tests/attr/test_occlusion.py -q -p no:cacheprovider`
- `D:\Dev\Miniconda3\python.exe -m pytest tests/attr/test_feature_ablation.py -q -p no:cacheprovider`
