### PR TITLE
Resolve pyre-fixme in common.py

### DIFF
--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -953,14 +953,13 @@ def _compute_jacobian_sample_wise_grads_per_batch(
     )
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def _compute_batch_loss_influence_function_base(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     loss_fn: Optional[Union[Module, Callable]],
     input: Any,
     target: Any,
     reduction_type: str,
-):
+) -> Tensor:
     """
     In implementations of `InfluenceFunctionBase`, we need to compute the total loss
     for a batch given `loss_fn`, whose reduction can either be 'none', 'sum', or


### PR DESCRIPTION
Summary:
Resolves the `pyre-fixme[3]` suppression on `_compute_batch_loss_influence_function_base` in `captum/influence/_utils/common.py` by adding the missing return type annotation.

All returning branches of the function produce a `Tensor`:
- `torch.sum(_loss)` for `reduction_type == "none"`
- `_loss * multiplier` for `reduction_type == "mean"`
- `_loss` for `reduction_type == "sum"`

Both call sites (`influence_function.py` and `arnoldi_influence_function.py`) pass the result to `torch.autograd.functional.hvp`/`hessian`, which require a scalar `Tensor`, so `Tensor` is the correct annotation.

Differential Revision: D116294308


