### PR TITLE
Require `no_grad` for `PerturbationAttribution.attribute` implementations (#1899)

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -293,6 +293,7 @@ class FeatureAblation(PerturbationAttribution):
         self._min_examples_per_batch_grouped: Optional[int] = None
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -107,6 +107,7 @@ class FeaturePermutation(FeatureAblation):
     # suppressing error caused by the child class not having a matching
     # signature to the parent
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(  # type: ignore
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -57,6 +57,7 @@ class KernelShap(Lime):
         self.inf_weight = 1000000.0
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(  # type: ignore
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
@@ -426,6 +427,7 @@ class RandomBaselineKernelShap(KernelShap):
         self.inf_weight = 1000000.0
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(  # type: ignore
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -69,6 +69,7 @@ class LayerFeatureAblation(LayerAttribution, PerturbationAttribution):
         PerturbationAttribution.__init__(self, forward_func)
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/attr/_core/layer/layer_feature_permutation.py
+++ b/captum/attr/_core/layer/layer_feature_permutation.py
@@ -62,6 +62,7 @@ class LayerFeaturePermutation(LayerAttribution, FeaturePermutation):
         FeaturePermutation.__init__(self, forward_func)
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -929,6 +929,7 @@ class Lime(LimeBase):
         )
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(  # type: ignore
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -66,6 +66,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
         PerturbationAttribution.__init__(self, forward_func)
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -53,6 +53,7 @@ class Occlusion(FeatureAblation):
         self.use_weights = True
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(  # type: ignore
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -128,6 +128,7 @@ class ShapleyValueSampling(PerturbationAttribution):
         self.permutation_generator = _perm_generator
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
@@ -1055,6 +1056,7 @@ class ShapleyValues(ShapleyValueSampling):
         self.permutation_generator = _all_perm_generator
 
     @log_usage(part_of_slo=True)
+    @torch.no_grad()
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, cast, Generic, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, cast, Generic, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn.functional as F
@@ -353,6 +353,10 @@ class PerturbationAttribution(Attribution):
     that we want to interpret or the model itself.
     """
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._raise_if_runs_with_grad()
+
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     def __init__(self, forward_func: Callable) -> None:
         r"""
@@ -367,6 +371,35 @@ class PerturbationAttribution(Attribution):
     @property
     def multiplies_by_inputs(self) -> bool:
         return True
+
+    @staticmethod
+    def _is_decorated_with_no_grad(method: object) -> bool:
+        # torch.no_grad()(fn) closes over the context manager itself, so the
+        # decorator is identified by the object rather than by any name torch
+        # may change.
+        while method is not None:
+            for cell in getattr(method, "__closure__", None) or ():
+                try:
+                    closed_over = cell.cell_contents
+                except ValueError:
+                    continue
+                if isinstance(
+                    getattr(closed_over, "__self__", closed_over), torch.no_grad
+                ):
+                    return True
+            method = getattr(method, "__wrapped__", None)
+        return False
+
+    @classmethod
+    def _raise_if_runs_with_grad(cls) -> None:
+        method = cls.__dict__.get("attribute")
+        if method is None or cls._is_decorated_with_no_grad(method):
+            return
+        raise TypeError(
+            f"{cls.__module__}.{cls.__qualname__}.attribute should be decorated "
+            "with @torch.no_grad() to avoid wasting memory on an autograd graph "
+            "that perturbation attribution never differentiates."
+        )
 
 
 # mypy false positive "Free type variable expected in Generic[...]" but

--- a/tests/attr/test_perturbation_attribution.py
+++ b/tests/attr/test_perturbation_attribution.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import torch
+from captum.attr._utils.attribution import PerturbationAttribution
+from captum.testing.helpers import BaseTest
+from torch import Tensor
+
+
+# pyrefly: ignore [invalid-inheritance]
+class PerturbationAttributionTest(BaseTest):
+    def test_undecorated_attribute_is_rejected(self) -> None:
+        with self.assertRaises(TypeError):
+
+            class Undecorated(PerturbationAttribution):
+                def attribute(self, inputs: Tensor) -> Tensor:
+                    return inputs
+
+    def test_no_grad_decorated_attribute_is_accepted(self) -> None:
+        class Decorated(PerturbationAttribution):
+            @torch.no_grad()
+            def attribute(self, inputs: Tensor) -> Tensor:
+                return inputs
+
+        self.assertTrue(issubclass(Decorated, PerturbationAttribution))


### PR DESCRIPTION
Summary:

Currently, any algorithm which uses Lime, such as Kernel SHAP, wastes a significant amount of memory due to a probe _run_forward call which falls outside torch.no_grad.

With this PR, we now require any subclass of PerturbationAttribution to decorate its attribute override with torch.no_grad.

On testing with production jobs, this saved 5+ GB of memory steadily throughout their lifetime. (Exact amount depends on the model.)

Differential Revision: D116173825


