### PR TITLE
Restore `[43]` suppression for OSS pyre parity

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -448,7 +448,7 @@ def _extract_device_ids(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
-#  not accept all possible arguments of overload defined on line `378`.
+#  not accept all possible arguments of this overload.
 def _forward_layer_eval_with_neuron_grads(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     forward_fn: Callable,
@@ -465,6 +465,8 @@ def _forward_layer_eval_with_neuron_grads(
 
 
 @typing.overload
+# pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
+#  not accept all possible arguments of this overload.
 def _forward_layer_eval_with_neuron_grads(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     forward_fn: Callable,
@@ -480,7 +482,7 @@ def _forward_layer_eval_with_neuron_grads(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
-#  not accept all possible arguments of overload defined on line `392`.
+#  not accept all possible arguments of this overload.
 def _forward_layer_eval_with_neuron_grads(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     forward_fn: Callable,


### PR DESCRIPTION
Summary:
The OSS GitHub Actions `Type checks` job fails on `captum/_utils/gradient.py` with:

```
captum/_utils/gradient.py:468:0 Incompatible overload [43]: The implementation of `_forward_layer_eval_with_neuron_grads` does not accept all possible arguments of overload defined on line `468`.
```

D114900914 removed the `# pyre-fixme[43]` suppression above the second `typing.overload` of `_forward_layer_eval_with_neuron_grads`, on the belief that it was stale. It was not stale — it was still load-bearing for the OSS pyre version pinned in `pyproject.toml` (`pyre-check-nightly==0.0.101750936314`), which is what `.github/workflows/type-checks.yml` runs.

The reason that removal looked safe is a genuine asymmetry between the two checkers, which I confirmed empirically: internal pyre (`arc pyre check-owning-targets`) does **not** report unused suppressions. I inserted a deliberately bogus `# pyre-fixme[43]` into this file and internal pyre still reported `No type errors found`. So a green internal run cannot distinguish a stale suppression from a necessary one, whereas OSS pyre runs `strict = true` via `.pyre_configuration.external` and does flag the missing suppression as an error.

This restores the suppression so both checkers pass, keeping OSS and internal pyre in sync as requested.

To reduce the chance of this drifting again, the restored comment and its two siblings now say "of this overload" instead of hardcoding a line number. The existing numbers were already stale (they referenced lines `378` and `392`, while the overloads actually start at 449/467/481), so they were actively misleading — the error text in the task quotes line `468` for the overload defined on line `468`. This matches the wording precedent set in D114178254 for `compute_layer_gradients_and_eval` in this same file.

Comment-only change; no runtime or typing-contract change.

Differential Revision: D116808828


