### PR TITLE
Make formatting compatible across Black versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,6 @@ jobs:
     with:
       runner: linux.12xlarge
       docker-image: cimg/python:3.11
-      repository: pytorch/captum
       script: |
         sudo chmod -R 777 .
         ./scripts/install_via_pip.sh

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -42,7 +42,6 @@ jobs:
     with:
       runner: linux.12xlarge
       docker-image: ${{ matrix.docker_img }}
-      repository: pytorch/captum
       script: |
         sudo chmod -R 777 .
         ./scripts/install_via_pip.sh ${{ matrix.pytorch_args }} ${{ matrix.transformers_args }}

--- a/.github/workflows/test-pip-gpu.yml
+++ b/.github/workflows/test-pip-gpu.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       timeout: 60
       runner: linux.4xlarge.nvidia.gpu
-      repository: pytorch/captum
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       script: |

--- a/.github/workflows/type-checks.yml
+++ b/.github/workflows/type-checks.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       runner: linux.12xlarge
       docker-image: cimg/python:3.11
-      repository: pytorch/captum
       script: |
         sudo chmod -R 777 .
         ./scripts/install_via_pip.sh ${{ matrix.pytorch_args }} -d

--- a/captum/__init__.py
+++ b/captum/__init__.py
@@ -8,7 +8,6 @@ import captum.log as log
 import captum.metrics as metrics
 import captum.robust as robust
 
-
 __version__ = "0.9.0"
 
 __all__ = ["attr", "concept", "influence", "log", "metrics", "robust"]

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -749,18 +749,15 @@ def _extract_device(
         and (hook_outputs is None or len(hook_outputs) == 0)
         and len(params) == 0
     ):
-        raise RuntimeError(
-            """Unable to extract device information for the module
-            {}. Both inputs and outputs to the forward hook and
+        message = f"""Unable to extract device information for the module
+            {module}. Both inputs and outputs to the forward hook and
             `module.parameters()` are empty.
             The reason that the inputs to the forward hook are empty
             could be due to the fact that the arguments to that
-            module {} are all named and are passed as named
+            module {module} are all named and are passed as named
             variables to its forward function.
-            """.format(
-                module, module
-            )
-        )
+            """
+        raise RuntimeError(message)
     if hook_inputs is not None and len(hook_inputs) > 0:
         return hook_inputs[0].device
     if hook_outputs is not None and len(hook_outputs) > 0:

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -64,13 +64,10 @@ def apply_gradient_requirements(
             hasattr(inputs_dtype, "is_complex") and inputs_dtype.is_complex
         ):
             if warn:
-                warnings.warn(
-                    """Input Tensor %d has a dtype of %s.
+                message = f"""Input Tensor {index} has a dtype of {inputs_dtype}.
                     Gradients cannot be activated
                     for these data types."""
-                    % (index, str(inputs_dtype)),
-                    stacklevel=2,
-                )
+                warnings.warn(message, stacklevel=2)
         elif not input.requires_grad:
             if warn:
                 warnings.warn(

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -35,7 +35,6 @@ from captum.log import log_usage
 from torch import dtype, Tensor
 from torch.futures import collect_all, Future
 
-
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -608,7 +607,7 @@ class FeatureAblation(PerturbationAttribution):
         )
         all_feature_idxs = list(feature_idx_to_tensor_idx.keys())
 
-        (all_features_repeated, additional_args_repeated, target_repeated) = (
+        all_features_repeated, additional_args_repeated, target_repeated = (
             _maybe_expand_parameters(
                 perturbations_per_eval,
                 formatted_inputs,
@@ -919,7 +918,7 @@ class FeatureAblation(PerturbationAttribution):
         )
         all_feature_idxs = list(feature_idx_to_tensor_idx.keys())
 
-        (all_features_repeated, additional_args_repeated, target_repeated) = (
+        all_features_repeated, additional_args_repeated, target_repeated = (
             _maybe_expand_parameters(
                 perturbations_per_eval,
                 formatted_inputs,

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -675,7 +675,7 @@ class ShapleyValueSampling(PerturbationAttribution):
     ) -> Tuple[Tensor, Tensor, Size, List[Tensor], bool]:
         """At the beginning of each feature permutation, the prev_results is
         reset to the initial eval, and this method helps set that up"""
-        (initial_eval, prev_results, output_shape, total_attrib, agg_output_mode) = (
+        initial_eval, prev_results, output_shape, total_attrib, agg_output_mode = (
             processed_initial_eval.value()
         )
         prev_results = initial_eval

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -1203,11 +1203,10 @@ def format_special_tokens(token: str) -> str:
 
 
 def format_tooltip(item: str, text: str) -> str:
-    return '<div class="tooltip">{item}\
+    tooltip = '<div class="tooltip">{item}\
         <span class="tooltiptext">{text}</span>\
-        </div>'.format(
-        item=item, text=text
-    )
+        </div>'
+    return tooltip.format(item=item, text=text)
 
 
 def format_word_importances(
@@ -1225,11 +1224,10 @@ def format_word_importances(
     for word, importance in zip(words, importances[: len(words)]):
         word = html.escape(format_special_tokens(word))
         color = _get_color(importance)
-        unwrapped_tag = '<mark style="background-color: {color}; opacity:1.0; \
+        unwrapped_tag_template = '<mark style="background-color: {color}; opacity:1.0; \
                     line-height:1.75"><font color="black"> {word}\
-                    </font></mark>'.format(
-            color=color, word=word
-        )
+                    </font></mark>'
+        unwrapped_tag = unwrapped_tag_template.format(color=color, word=word)
         tags.append(unwrapped_tag)
     tags.append("</td>")
     return "".join(tags)
@@ -1280,20 +1278,18 @@ def visualize_text(
         )
 
     if legend:
-        dom.append(
-            '<div style="border-top: 1px solid; margin-top: 5px; \
+        legend_html = '<div style="border-top: 1px solid; margin-top: 5px; \
             padding-top: 5px; display: inline-block">'
-        )
+        dom.append(legend_html)
         dom.append("<b>Legend: </b>")
 
+        color_box_template = (
+            '<span style="display: inline-block; width: 10px; height: 10px; '
+            "                border: 1px solid; background-color: "
+            '                {value}"></span> {label}  '
+        )
         for value, label in zip([-1, 0, 1], ["Negative", "Neutral", "Positive"]):
-            dom.append(
-                '<span style="display: inline-block; width: 10px; height: 10px; \
-                border: 1px solid; background-color: \
-                {value}"></span> {label}  '.format(
-                    value=_get_color(value), label=label
-                )
-            )
+            dom.append(color_box_template.format(value=_get_color(value), label=label))
         dom.append("</div>")
 
     dom.append("".join(rows))

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -45,7 +45,6 @@ from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
 
-
 r"""
 
 Note: methods starting with "_" are protected, not private, and can be overridden in

--- a/tests/test_tutorial_regressions.py
+++ b/tests/test_tutorial_regressions.py
@@ -11,7 +11,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-
 TUTORIALS_PATH = Path(__file__).resolve().parents[1] / "tutorials"
 
 


### PR DESCRIPTION
Summary:
OSS Captum's `pyproject.toml` pins `black==26.3.1` while fbsource pins
`25.11.0`. Black 26 hugs multiline strings against the enclosing call and
drops redundant parentheses around unpacking targets; Black 25.11 explodes
them. Eight files were written in a shape only one of the two versions
accepts, so `ufmt check .` could not pass on both.

Rewrite those spots into forms both versions agree on:

- Extract multiline strings into a local before passing them to
  `warnings.warn` / `str.format` / `list.append`, so no multiline string
  is a call argument.
- Convert the `%`-formatted messages in `captum/_utils/common.py` and
  `captum/_utils/gradient.py` to f-strings.
- Drop the redundant parentheses around the unpacking targets in
  `captum/attr/_core/feature_ablation.py` and
  `captum/attr/_core/shapley_value.py`.
- Drop the extra blank lines Black 26 collapses in `captum/__init__.py`,
  `tests/test_tutorial_regressions.py`, `captum/influence/_core/tracincp.py`
  and `captum/attr/_core/feature_ablation.py`.

All rewrites are output-preserving; the rendered strings are byte-identical.

This also fixes the GitHub CI checkout, without which the change above
cannot be validated on a PR. The four workflows that delegate to
`pytorch/test-infra`'s `linux_job_v2.yml` pass `repository: pytorch/captum`.
The repo has since been renamed to `meta-pytorch/captum`, so that value no
longer equals `github.repository`. `actions/checkout` only honors the
triggering event's ref when the requested repository *is* the workflow's own
repository, so checkout falls back to the default branch. Every
`pull_request` run of `Captum Lint`, `Type checks`, and both
`Unit-tests for Pip install` workflows has therefore been testing `master`
and ignoring the PR. Dropping the line lets the input default to
`github.repository`, which matches the triggering repository and keeps
working for forks.

Reviewed By: jjuncho

Differential Revision: D117461310


