### PR TITLE
Make async and grouped perturbation attribution correct (#1923)

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -36,6 +36,24 @@ from torch.futures import Future
 from torch.nn import Module
 
 
+def _generate_derangement(n: int, device: torch.device | None = None) -> Tensor:
+    """Generate a random cyclic donor ordering without fixed points.
+
+    A random cycle gives every row a uniformly distributed donor among the
+    other rows while requiring only one device-side ``randperm`` and no
+    device-to-host synchronization. The result is a valid derangement for
+    every ``n > 1``.
+    """
+    row_indices = torch.arange(n, device=device)
+    if n <= 1:
+        return row_indices
+
+    cycle = torch.randperm(n, device=device)
+    permutation = torch.empty_like(cycle)
+    permutation[cycle] = torch.roll(cycle, shifts=-1)
+    return permutation
+
+
 def parse_version(v: str) -> Tuple[int, ...]:
     """
     Parse version strings into tuples for comparison.

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -117,6 +117,7 @@ def _validate_input(
     inputs: Tuple[Tensor, ...],
     baselines: Tuple[Union[Tensor, int, float], ...],
     draw_baseline_from_distrib: bool = False,
+    allow_broadcastable_baselines: bool = False,
 ) -> None:
     assert len(inputs) == len(baselines), (
         "Input and baseline must have the same "
@@ -137,10 +138,24 @@ def _validate_input(
                 " Found baseline: {} and input: {} ".format(baseline, input)
             )
         else:
+            baseline_is_broadcastable = False
+            if allow_broadcastable_baselines and isinstance(baseline, Tensor):
+                try:
+                    baseline_is_broadcastable = (
+                        torch.broadcast_shapes(input.shape, baseline.shape)
+                        == input.shape
+                    )
+                except RuntimeError:
+                    pass
             assert (
                 isinstance(baseline, (int, float))
                 or input.shape == baseline.shape
-                or baseline.shape[0] == 1
+                or (
+                    baseline.dim() > 0
+                    and baseline.shape[0] == 1
+                    and input.shape[1:] == baseline.shape[1:]
+                )
+                or baseline_is_broadcastable
             ), (
                 "Baseline can be provided as a tensor for just one input and"
                 " broadcasted to the batch or input and baseline must have the"

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -241,6 +241,10 @@ def _format_feature_mask(
 
     else:
         formatted_mask = _format_tensor_into_tuples(feature_mask)
+        assert len(formatted_mask) == len(inputs), (
+            "Input and feature mask must have the same number of tensors, "
+            f"but input has {len(inputs)} and feature mask has {len(formatted_mask)}."
+        )
 
     return formatted_mask
 

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -22,6 +22,7 @@ from captum._utils.common import (
     _is_tuple,
     _maybe_expand_parameters,
     _run_forward,
+    _validate_input,
 )
 from captum._utils.exceptions import FeatureAblationFutureError
 from captum._utils.progress import NullProgress, progress, Progress
@@ -501,6 +502,7 @@ class FeatureAblation(PerturbationAttribution):
         is_inputs_tuple = _is_tuple(inputs)
 
         formatted_inputs, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(formatted_inputs, baselines, allow_broadcastable_baselines=True)
         formatted_additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
@@ -834,6 +836,7 @@ class FeatureAblation(PerturbationAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
         formatted_inputs, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(formatted_inputs, baselines, allow_broadcastable_baselines=True)
         formatted_additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -784,9 +784,9 @@ class FeatureAblation(PerturbationAttribution):
                 tensor_mask.append(mask)
 
                 assert baseline is not None, "baseline must be provided"
-                ablated_feature = input_tensor[start_idx:end_idx] * (1 - mask).to(
-                    input_tensor.dtype
-                ) + (baseline * mask.to(input_tensor.dtype))
+                ablated_feature = torch.where(
+                    mask.bool(), baseline, input_tensor[start_idx:end_idx]
+                )
                 ablated_input = ablated_input.to(ablated_feature.dtype)
                 ablated_input[start_idx:end_idx] = ablated_feature
             current_masks.append(torch.stack(tensor_mask, dim=0))
@@ -1211,6 +1211,10 @@ class FeatureAblation(PerturbationAttribution):
                 eval_diff_shape + (inputs[i].dim() - 1) * (1,)
             )
             eval_diff = eval_diff.to(total_attrib[i].device)
-            total_attrib[i] += (eval_diff * mask.to(attrib_type)).sum(dim=0)
+            total_attrib[i] += torch.where(
+                mask.to(device=eval_diff.device, dtype=torch.bool),
+                eval_diff,
+                torch.zeros_like(eval_diff),
+            ).sum(dim=0)
 
         return total_attrib, weights

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -632,6 +632,7 @@ class FeatureAblation(PerturbationAttribution):
                 else:
                     reshaped_baselines.append(baseline)
             baselines = tuple(reshaped_baselines) if reshaped else baselines
+        should_validate_output_shape = True
         for i in range(0, len(all_feature_idxs), perturbations_per_eval):
             current_feature_idxs = all_feature_idxs[i : i + perturbations_per_eval]
             current_num_ablated_features = min(
@@ -703,8 +704,8 @@ class FeatureAblation(PerturbationAttribution):
                 "when use_futures is True, modified_eval should have "
                 f"non-Future type rather than {type(modified_eval)}"
             )
-            # Just do the check once.
-            if not self._is_output_shape_valid:
+            # Validate once for each attribution call.
+            if should_validate_output_shape:
                 check_output_shape_valid(
                     inputs=current_inputs,
                     num_examples=num_examples,
@@ -712,7 +713,7 @@ class FeatureAblation(PerturbationAttribution):
                     modified_eval=modified_eval,
                     perturbations_per_eval=perturbations_per_eval,
                 )
-                self._is_output_shape_valid = True
+                should_validate_output_shape = False
             total_attrib, weights = self._process_ablated_out_full(
                 modified_eval=modified_eval,
                 current_mask=current_masks,
@@ -825,11 +826,15 @@ class FeatureAblation(PerturbationAttribution):
         feature_mask: Union[None, Tensor, Tuple[Tensor, ...]] = None,
         perturbations_per_eval: int = 1,
         show_progress: bool = False,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> Future[TensorOrTupleOfTensorsGeneric]:
         r"""
         Almost the same as the attribute function, except that it requires a
-        forward function that returns a Future, and it returns a Future.
+        forward function that returns a Future, and it returns a Future. When
+        ``run_forward_on_skip`` is enabled, failures from a skipped group's
+        alignment-only forward are ignored because its output is intentionally
+        excluded from the attribution result.
         """
 
         # Keeps track whether original input is a tuple or not before
@@ -898,6 +903,8 @@ class FeatureAblation(PerturbationAttribution):
                     processed_initial_eval_fut=processed_initial_eval_fut,
                     is_inputs_tuple=is_inputs_tuple,
                     perturbations_per_eval=perturbations_per_eval,
+                    run_forward_on_skip=run_forward_on_skip,
+                    **kwargs,
                 ),
             )
 
@@ -914,6 +921,7 @@ class FeatureAblation(PerturbationAttribution):
         ],
         is_inputs_tuple: bool,
         perturbations_per_eval: int,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> Future[Union[Tensor, Tuple[Tensor, ...]]]:
         feature_idx_to_tensor_idx = self._get_feature_idx_to_tensor_idx(
@@ -952,11 +960,25 @@ class FeatureAblation(PerturbationAttribution):
                 perturbations_per_eval, len(current_feature_idxs)
             )
 
-            if self._should_skip_inputs_and_warn(
+            should_skip = self._should_skip_inputs_and_warn(
                 current_feature_idxs,
                 feature_idx_to_tensor_idx,
                 formatted_inputs,
-            ):
+            )
+            if should_skip and run_forward_on_skip:
+                skipped_eval = _run_forward(
+                    self.forward_func,
+                    formatted_inputs,
+                    target,
+                    formatted_additional_forward_args,
+                )
+                if not isinstance(skipped_eval, torch.Future):
+                    raise AssertionError(
+                        "when using attribute_future, skipped_eval should have "
+                        f"Future type rather than {type(skipped_eval)}"
+                    )
+                all_modified_eval_futures.append(skipped_eval.then(lambda _: ([], [])))
+            if should_skip:
                 continue
 
             # Store appropriate inputs and additional args based on batch size.
@@ -1051,25 +1073,9 @@ class FeatureAblation(PerturbationAttribution):
 
         return self._generate_async_result_cross_tensor(
             all_modified_eval_futures,
+            processed_initial_eval_fut,
             is_inputs_tuple,
         )
-
-    def _fut_tuple_to_accumulate_fut_list_cross_tensor(
-        self,
-        total_attrib: List[Tensor],
-        weights: List[Tensor],
-        fut_tuple: Future[Tuple[List[Tensor], List[Tensor]]],
-    ) -> None:
-        try:
-            # process_ablated_out_* already accumlates the total attribution.
-            # Just get the latest value
-            attribs, this_weights = fut_tuple.value()
-            total_attrib[:] = attribs
-            weights[:] = this_weights
-        except FeatureAblationFutureError as e:
-            raise FeatureAblationFutureError(
-                "_fut_tuple_to_accumulate_fut_list_cross_tensor failed"
-            ) from e
 
     def _attribute_progress_setup(
         self,
@@ -1090,28 +1096,55 @@ class FeatureAblation(PerturbationAttribution):
     def _generate_async_result_cross_tensor(
         self,
         futs: List[Future[Tuple[List[Tensor], List[Tensor]]]],
+        processed_initial_eval_fut: Future[
+            Tuple[List[Tensor], List[Tensor], Tensor, Tensor, int, dtype]
+        ],
         is_inputs_tuple: bool,
     ) -> Future[Union[Tensor, Tuple[Tensor, ...]]]:
-        accumulate_fut_list: List[Future[None]] = []
-        total_attrib: List[Tensor] = []
-        weights: List[Tensor] = []
-
-        for fut_tuple in futs:
-            accumulate_fut_list.append(
-                fut_tuple.then(
-                    lambda fut_tuple: self._fut_tuple_to_accumulate_fut_list_cross_tensor(  # noqa: E501 line too long
-                        total_attrib, weights, fut_tuple
-                    )
-                )
+        def reduce_results(
+            collected: Future[
+                List[
+                    Future[
+                        Union[
+                            Tuple[
+                                List[Tensor],
+                                List[Tensor],
+                                Tensor,
+                                Tensor,
+                                int,
+                                dtype,
+                            ],
+                            Tuple[List[Tensor], List[Tensor]],
+                        ]
+                    ]
+                ]
+            ],
+        ) -> Union[Tensor, Tuple[Tensor, ...]]:
+            initial_result = cast(
+                Tuple[List[Tensor], List[Tensor], Tensor, Tensor, int, dtype],
+                collected.value()[0].value(),
             )
-
-        result_fut = collect_all(accumulate_fut_list).then(
-            lambda x: format_result(
+            total_attrib = [torch.zeros_like(attr) for attr in initial_result[0]]
+            weights = [torch.zeros_like(weight) for weight in initial_result[1]]
+            for result_future in collected.value()[1:]:
+                attrs, result_weights = cast(
+                    Tuple[List[Tensor], List[Tensor]], result_future.value()
+                )
+                if attrs:
+                    total_attrib = [
+                        total + contribution
+                        for total, contribution in zip(total_attrib, attrs)
+                    ]
+                if result_weights:
+                    weights = [
+                        total + contribution
+                        for total, contribution in zip(weights, result_weights)
+                    ]
+            return format_result(
                 total_attrib, weights, is_inputs_tuple, use_weights=self.use_weights
             )
-        )
 
-        return result_fut
+        return collect_all([processed_initial_eval_fut, *futs]).then(reduce_results)
 
     def _eval_fut_to_ablated_out_fut_cross_tensor(
         self,
@@ -1148,23 +1181,23 @@ class FeatureAblation(PerturbationAttribution):
                     "modified eval should be a Tensor"
                 )
             (
-                total_attrib,
-                weights,
+                initial_total_attrib,
+                initial_weights,
                 initial_eval,
                 flattened_initial_eval,
                 n_outputs,
                 attrib_type,
             ) = initial_eval_tuple
-            # Just do the check once.
-            if not self._is_output_shape_valid:
-                check_output_shape_valid(
-                    inputs=current_inputs,
-                    num_examples=num_examples,
-                    initial_eval=initial_eval,
-                    modified_eval=modified_eval,
-                    perturbations_per_eval=perturbations_per_eval,
-                )
-                self._is_output_shape_valid = True
+            check_output_shape_valid(
+                inputs=current_inputs,
+                num_examples=num_examples,
+                initial_eval=initial_eval,
+                modified_eval=modified_eval,
+                perturbations_per_eval=perturbations_per_eval,
+            )
+
+            total_attrib = [torch.zeros_like(attr) for attr in initial_total_attrib]
+            weights = [torch.zeros_like(weight) for weight in initial_weights]
 
             total_attrib, weights = self._process_ablated_out_full(
                 modified_eval=modified_eval,

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -26,9 +26,7 @@ def _permute_feature(x: Tensor, feature_mask: Tensor) -> Tensor:
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    return (x[perm] * feature_mask.to(dtype=x.dtype)) + (
-        x * feature_mask.bitwise_not().to(dtype=x.dtype)
-    )
+    return torch.where(feature_mask.to(device=x.device, dtype=torch.bool), x[perm], x)
 
 
 class FeaturePermutation(FeatureAblation):

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -18,17 +18,22 @@ from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensor
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.log import log_usage
 from torch import Tensor
-from torch.futures import Future
+from torch.futures import collect_all, Future
+
+
+def _generate_permutation(n: int, device: Optional[torch.device] = None) -> Tensor:
+    row_indices = torch.arange(n, device=device)
+    if n <= 1:
+        return row_indices
+    permutation = torch.randperm(n, device=device)
+    while (permutation == row_indices).all():
+        permutation = torch.randperm(n, device=device)
+    return permutation
 
 
 def _permute_feature(x: Tensor, feature_mask: Tensor) -> Tensor:
     n = x.size(0)
-    assert n > 1, "cannot permute features with batch_size = 1"
-
-    perm = torch.randperm(n)
-    no_perm = torch.arange(n)
-    while (perm == no_perm).all():
-        perm = torch.randperm(n)
+    perm = _generate_permutation(n, x.device)
 
     return torch.where(feature_mask.to(device=x.device, dtype=torch.bool), x[perm], x)
 
@@ -40,6 +45,16 @@ def _permute_feature_without_self_donors(x: Tensor, feature_mask: Tensor) -> Ten
     perm = _generate_derangement(n, x.device)
 
     return torch.where(feature_mask.to(device=x.device, dtype=torch.bool), x[perm], x)
+
+
+def _permute_feature_with_indices(
+    x: Tensor, feature_mask: Tensor, permutation: Tensor
+) -> Tensor:
+    return torch.where(
+        feature_mask.to(device=x.device, dtype=torch.bool),
+        x[permutation.to(x.device)],
+        x,
+    )
 
 
 class FeaturePermutation(FeatureAblation):
@@ -99,6 +114,9 @@ class FeaturePermutation(FeatureAblation):
         self,
         forward_func: Callable[..., Union[int, float, Tensor, Future[Tensor]]],
         perm_func: Callable[[Tensor, Tensor], Tensor] | None = None,
+        grouped_perm_func: Optional[
+            Callable[[Tuple[Tensor, ...], Tuple[Tensor, ...]], Tuple[Tensor, ...]]
+        ] = None,
         exclude_self_donors: bool = False,
     ) -> None:
         r"""
@@ -112,6 +130,12 @@ class FeaturePermutation(FeatureAblation):
                 which applies a random permutation, this argument only needs
                 to be provided if a custom permutation behavior is desired.
                 Default: `_permute_feature`
+            grouped_perm_func (Callable, optional): A function that atomically
+                permutes a feature group spanning multiple input tensors. It accepts
+                tuples of aligned input batches and masks and must return a tuple of
+                tensors with matching shapes. This is required for cross-tensor groups
+                when ``perm_func`` is custom, since independently invoking an arbitrary
+                transform cannot guarantee shared donor rows. Default: None
             exclude_self_donors (bool, optional): If True, every selected row
                 receives its value from a different donor row. This cannot be
                 combined with a custom ``perm_func``. Default: False
@@ -126,6 +150,7 @@ class FeaturePermutation(FeatureAblation):
             if exclude_self_donors
             else perm_func if perm_func is not None else _permute_feature
         )
+        self.grouped_perm_func = grouped_perm_func
         # Considering the case when we permute multiple input tensors at once
         # through `feature_mask`, we disregard the feature group if the 0th
         # dim of *any* input tensor in the group is less than
@@ -401,24 +426,60 @@ class FeaturePermutation(FeatureAblation):
         feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
         perturbations_per_eval: int = 1,
         show_progress: bool = False,
+        n_samples: int = 1,
+        run_forward_on_skip: bool = False,
         **kwargs: Any,
     ) -> Future[TensorOrTupleOfTensorsGeneric]:
         """
         Similar to attribute(), but supports async forward functions.
+
+        Args:
+            n_samples: Number of independently sampled permutations to average.
+            run_forward_on_skip: Run an unchanged forward pass when a feature group
+                cannot be permuted, keeping distributed forward counts aligned.
         """
+        assert (
+            isinstance(n_samples, int) and n_samples >= 1
+        ), "n_samples must be an integer and at least 1."
         if isinstance(kwargs, dict) and "baselines" in kwargs:
             del kwargs["baselines"]
-        return FeatureAblation.attribute_future.__wrapped__(
-            self,
-            inputs,
-            baselines=None,
-            target=target,
-            additional_forward_args=additional_forward_args,
-            feature_mask=feature_mask,
-            perturbations_per_eval=perturbations_per_eval,
-            show_progress=show_progress,
-            **kwargs,
-        )
+        attribution_futures = [
+            FeatureAblation.attribute_future.__wrapped__(
+                self,
+                inputs,
+                baselines=None,
+                target=target,
+                additional_forward_args=additional_forward_args,
+                feature_mask=feature_mask,
+                perturbations_per_eval=perturbations_per_eval,
+                show_progress=show_progress,
+                run_forward_on_skip=run_forward_on_skip,
+                **kwargs,
+            )
+            for _ in range(n_samples)
+        ]
+        if n_samples == 1:
+            return attribution_futures[0]
+
+        is_attrib_tuple = isinstance(inputs, tuple)
+
+        def average_attributions(
+            collected: Future[List[Future[TensorOrTupleOfTensorsGeneric]]],
+        ) -> TensorOrTupleOfTensorsGeneric:
+            formatted_attributions = [
+                _format_tensor_into_tuples(attribution.value())
+                for attribution in collected.value()
+            ]
+            averaged_attributions = tuple(
+                torch.stack(values).mean(dim=0)
+                for values in zip(*formatted_attributions)
+            )
+            return cast(
+                TensorOrTupleOfTensorsGeneric,
+                _format_output(is_attrib_tuple, averaged_attributions),
+            )
+
+        return collect_all(attribution_futures).then(average_attributions)
 
     def _construct_ablated_input_across_tensors(
         self,
@@ -438,6 +499,80 @@ class FeaturePermutation(FeatureAblation):
             )
             for tensor_idx in sublist
         }
+        shared_permutations: Dict[int, Tensor] = {}
+        grouped_permutations: Dict[Tuple[int, int], Tensor] = {}
+        for feature_idx in feature_idxs:
+            group_batch_sizes = {
+                inputs[tensor_idx].shape[0] // current_num_ablated_features
+                for tensor_idx in feature_idx_to_tensor_idx[feature_idx]
+            }
+            if len(group_batch_sizes) != 1:
+                raise ValueError(
+                    "A cross-tensor feature group must use the same batch size "
+                    "for every participating input tensor."
+                )
+        if self.perm_func in (_permute_feature, _permute_feature_without_self_donors):
+            for feature_idx in feature_idxs:
+                first_tensor_idx = feature_idx_to_tensor_idx[feature_idx][0]
+                num_examples = (
+                    inputs[first_tensor_idx].shape[0] // current_num_ablated_features
+                )
+                if self.perm_func is _permute_feature_without_self_donors:
+                    assert (
+                        num_examples > 1
+                    ), "cannot permute features with batch_size = 1"
+                    shared_permutations[feature_idx] = _generate_derangement(
+                        num_examples,
+                        device=inputs[first_tensor_idx].device,
+                    )
+                else:
+                    shared_permutations[feature_idx] = _generate_permutation(
+                        num_examples,
+                        device=inputs[first_tensor_idx].device,
+                    )
+        else:
+            for block_idx, feature_idx in enumerate(feature_idxs):
+                grouped_tensor_idxs = feature_idx_to_tensor_idx[feature_idx]
+                if len(grouped_tensor_idxs) <= 1:
+                    continue
+                if self.grouped_perm_func is None:
+                    raise ValueError(
+                        "A custom perm_func cannot be applied independently to a "
+                        "feature group spanning multiple input tensors. Provide "
+                        "grouped_perm_func to transform the aligned tensors atomically."
+                    )
+                grouped_inputs = []
+                grouped_masks = []
+                for tensor_idx in grouped_tensor_idxs:
+                    input_tensor = inputs[tensor_idx]
+                    original_input_size = (
+                        input_tensor.shape[0] // current_num_ablated_features
+                    )
+                    start_idx = block_idx * original_input_size
+                    end_idx = (block_idx + 1) * original_input_size
+                    grouped_inputs.append(input_tensor[start_idx:end_idx])
+                    grouped_masks.append(
+                        (input_mask[tensor_idx] == feature_idx)
+                        .to(input_tensor.device)
+                        .bool()
+                    )
+                grouped_outputs = self.grouped_perm_func(
+                    tuple(grouped_inputs), tuple(grouped_masks)
+                )
+                if len(grouped_outputs) != len(grouped_inputs):
+                    raise ValueError(
+                        "grouped_perm_func must return one tensor for each "
+                        "input tensor."
+                    )
+                for tensor_idx, original, permuted in zip(
+                    grouped_tensor_idxs, grouped_inputs, grouped_outputs
+                ):
+                    if permuted.shape != original.shape:
+                        raise ValueError(
+                            "grouped_perm_func outputs must match their input shapes."
+                        )
+                    grouped_permutations[(feature_idx, tensor_idx)] = permuted
+
         permuted_inputs = []
         for i, input_tensor in enumerate(inputs):
             if i not in tensor_idxs:
@@ -446,20 +581,31 @@ class FeaturePermutation(FeatureAblation):
                 continue
             tensor_mask = []
             permuted_input = input_tensor.clone()
-            for j, feature_idx in enumerate(feature_idxs):
+            for block_idx, feature_idx in enumerate(feature_idxs):
                 original_input_size = (
                     input_tensor.shape[0] // current_num_ablated_features
                 )
-                start_idx = j * original_input_size
-                end_idx = (j + 1) * original_input_size
+                start_idx = block_idx * original_input_size
+                end_idx = (block_idx + 1) * original_input_size
 
                 mask = (input_mask[i] == feature_idx).to(input_tensor.device).bool()
                 if mask.ndim == 0:
                     mask = mask.reshape((1,) * input_tensor.dim())
                 tensor_mask.append(mask)
-                permuted_input[start_idx:end_idx] = self.perm_func(
-                    input_tensor[start_idx:end_idx], mask
-                )
+                if feature_idx in shared_permutations:
+                    permuted_input[start_idx:end_idx] = _permute_feature_with_indices(
+                        input_tensor[start_idx:end_idx],
+                        mask,
+                        shared_permutations[feature_idx],
+                    )
+                elif (feature_idx, i) in grouped_permutations:
+                    permuted_input[start_idx:end_idx] = grouped_permutations[
+                        (feature_idx, i)
+                    ]
+                else:
+                    permuted_input[start_idx:end_idx] = self.perm_func(
+                        input_tensor[start_idx:end_idx], mask
+                    )
             current_masks.append(torch.stack(tensor_mask, dim=0))
             permuted_inputs.append(permuted_input)
 

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -9,7 +9,11 @@
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
 import torch
-from captum._utils.common import _format_output, _format_tensor_into_tuples
+from captum._utils.common import (
+    _format_output,
+    _format_tensor_into_tuples,
+    _generate_derangement,
+)
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.log import log_usage
@@ -25,6 +29,15 @@ def _permute_feature(x: Tensor, feature_mask: Tensor) -> Tensor:
     no_perm = torch.arange(n)
     while (perm == no_perm).all():
         perm = torch.randperm(n)
+
+    return torch.where(feature_mask.to(device=x.device, dtype=torch.bool), x[perm], x)
+
+
+def _permute_feature_without_self_donors(x: Tensor, feature_mask: Tensor) -> Tensor:
+    n = x.size(0)
+    assert n > 1, "cannot permute features with batch_size = 1"
+
+    perm = _generate_derangement(n, x.device)
 
     return torch.where(feature_mask.to(device=x.device, dtype=torch.bool), x[perm], x)
 
@@ -58,6 +71,11 @@ class FeaturePermutation(FeatureAblation):
     This method, unlike other attribution methods, requires a batch
     of examples to compute attributions and cannot be performed on a single example.
 
+    The default permutation may leave individual rows fixed. Set
+    ``exclude_self_donors=True`` to require every selected value to come from a
+    different row. Distinct donor rows may still contain equal feature values;
+    those are valid samples from the empirical feature distribution.
+
     By default, each scalar value within
     each input tensor is taken as a feature and shuffled independently. Passing
     a feature mask allows grouping features to be shuffled together (including
@@ -80,7 +98,8 @@ class FeaturePermutation(FeatureAblation):
     def __init__(
         self,
         forward_func: Callable[..., Union[int, float, Tensor, Future[Tensor]]],
-        perm_func: Callable[[Tensor, Tensor], Tensor] = _permute_feature,
+        perm_func: Callable[[Tensor, Tensor], Tensor] | None = None,
+        exclude_self_donors: bool = False,
     ) -> None:
         r"""
         Args:
@@ -93,9 +112,20 @@ class FeaturePermutation(FeatureAblation):
                 which applies a random permutation, this argument only needs
                 to be provided if a custom permutation behavior is desired.
                 Default: `_permute_feature`
+            exclude_self_donors (bool, optional): If True, every selected row
+                receives its value from a different donor row. This cannot be
+                combined with a custom ``perm_func``. Default: False
         """
         FeatureAblation.__init__(self, forward_func=forward_func)
-        self.perm_func = perm_func
+        if exclude_self_donors and perm_func is not None:
+            raise ValueError(
+                "exclude_self_donors cannot be combined with a custom perm_func"
+            )
+        self.perm_func = (
+            _permute_feature_without_self_donors
+            if exclude_self_donors
+            else perm_func if perm_func is not None else _permute_feature
+        )
         # Considering the case when we permute multiple input tensors at once
         # through `feature_mask`, we disregard the feature group if the 0th
         # dim of *any* input tensor in the group is less than

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -84,6 +84,21 @@ def _shape_feature_mask(
     return tuple(mask_list)
 
 
+def _validate_shapley_feature_mask(feature_mask: Tuple[Tensor, ...]) -> None:
+    for mask in feature_mask:
+        if mask.is_complex():
+            values_are_integral = False
+        elif mask.is_floating_point():
+            values_are_integral = bool(
+                torch.isfinite(mask).all() and (mask == mask.round()).all()
+            )
+        else:
+            values_are_integral = True
+        assert values_are_integral and (
+            mask.numel() == 0 or bool((mask >= 0).all())
+        ), "Feature mask values must be non-negative integers."
+
+
 class ShapleyValueSampling(PerturbationAttribution):
     """
     A perturbation based approach to compute attribution, based on the concept
@@ -326,6 +341,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             additional_forward_args
         )
         formatted_feature_mask = _format_feature_mask(feature_mask, inputs_tuple)
+        _validate_shapley_feature_mask(formatted_feature_mask)
         reshaped_feature_mask = _shape_feature_mask(
             formatted_feature_mask, inputs_tuple
         )
@@ -494,6 +510,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             additional_forward_args
         )
         formatted_feature_mask = _format_feature_mask(feature_mask, inputs_tuple)
+        _validate_shapley_feature_mask(formatted_feature_mask)
         reshaped_feature_mask = _shape_feature_mask(
             formatted_feature_mask, inputs_tuple
         )

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -37,6 +37,7 @@ from captum._utils.common import (
     _is_mask_valid,
     _is_tuple,
     _run_forward,
+    _validate_input,
 )
 from captum._utils.exceptions import ShapleyValueFutureError
 from captum._utils.progress import progress
@@ -320,6 +321,7 @@ class ShapleyValueSampling(PerturbationAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
         inputs_tuple, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(inputs_tuple, baselines)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
@@ -487,6 +489,7 @@ class ShapleyValueSampling(PerturbationAttribution):
     ) -> Future[TensorOrTupleOfTensorsGeneric]:
         is_inputs_tuple = _is_tuple(inputs)
         inputs_tuple, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(inputs_tuple, baselines)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -757,7 +757,11 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
             # aggregate n_perturb
-            cur_attr = (formatted_eval_diff * cur_mask.float()).sum(dim=0)
+            cur_attr = torch.where(
+                cur_mask.to(device=formatted_eval_diff.device, dtype=torch.bool),
+                formatted_eval_diff,
+                torch.zeros_like(formatted_eval_diff),
+            ).sum(dim=0)
             # (*output_shape, *input_feature_shape)
             total_attrib[j] += cur_attr
 
@@ -808,10 +812,11 @@ class ShapleyValueSampling(PerturbationAttribution):
         for i in range(len(current_tensors)):
             if i in feat_list:
                 output_tensors.append(
-                    current_tensors[i]
-                    * (~(mask[i] == feature_index)).to(current_tensors[i].dtype)
-                    + input_tensors[i]
-                    * (mask[i] == feature_index).to(input_tensors[i].dtype)
+                    torch.where(
+                        (mask[i] == feature_index).to(current_tensors[i].device),
+                        input_tensors[i],
+                        current_tensors[i],
+                    )
                 )
 
             else:

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -292,6 +292,10 @@ def _tensorize_baseline(
             type(baselines), type(inputs)
         )
     )
+    assert len(inputs) == len(baselines), (
+        "Input and baseline must have the same dimensions, baseline has "
+        f"{len(baselines)} features whereas input has {len(inputs)}."
+    )
     return tuple(
         _tensorize_single_baseline(baseline, input)
         for baseline, input in zip(baselines, inputs)

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -281,7 +281,16 @@ def _tensorize_baseline(
     # pyre-fixme[2]: Parameter must be annotated.
     def _tensorize_single_baseline(baseline, input):
         if isinstance(baseline, (int, float)):
-            return torch.full_like(input, baseline)
+            baseline_dtype = (
+                input.dtype
+                if input.dtype == torch.bool
+                else torch.result_type(input, baseline)
+            )
+            return torch.full_like(
+                input,
+                baseline,
+                dtype=baseline_dtype,
+            )
         if input.shape[0] > baseline.shape[0] and baseline.shape[0] == 1:
             return torch.cat([baseline] * input.shape[0])
         return baseline

--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -62,7 +62,7 @@ class Stat:
         assert self._other_stats is not None
         return cast(Optional[_S], self._other_stats.get(stat))
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         raise NotImplementedError()
 
     def get(self) -> Optional[StatValue]:
@@ -100,21 +100,20 @@ class Stat:
 
 class Count(Stat):
     """
-    Counts the number of elements, i.e. the
-    number of `update`'s called
+    Counts observations, including frequency weights supplied to `update`.
     """
 
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__(name=name)
-        self.n: Optional[int] = None
+        self.n: Optional[Union[int, float]] = None
 
-    def get(self) -> Optional[int]:
+    def get(self) -> Optional[Union[int, float]]:
         return self.n
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         if self.n is None:
             self.n = 0
-        self.n += 1
+        self.n += weight
 
 
 class Mean(Stat):
@@ -133,7 +132,7 @@ class Mean(Stat):
     def init(self) -> None:
         self.n = self._get_stat(Count())
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         assert self.n is not None
         n = self.n.get()
         assert n is not None
@@ -144,7 +143,7 @@ class Mean(Stat):
             self.rolling_mean = x.clone() if x.is_floating_point() else x.double()
         else:
             delta = x - rolling_mean
-            self.rolling_mean = rolling_mean + delta / n
+            self.rolling_mean = rolling_mean + delta * weight / n
 
 
 class MSE(Stat):
@@ -166,12 +165,12 @@ class MSE(Stat):
             return torch.zeros_like(self.prev_mean)
         return self.mse
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         assert self.mean is not None
         mean = self.mean.get()
 
         if mean is not None and self.prev_mean is not None:
-            rhs = (x - self.prev_mean) * (x - mean)
+            rhs = weight * (x - self.prev_mean) * (x - mean)
             if self.mse is None:
                 self.mse = rhs
             else:
@@ -207,7 +206,7 @@ class Var(Stat):
         self.mse_stat = self._get_stat(MSE())
         self.n_stat = self._get_stat(Count())
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         pass
 
     def get(self) -> Optional[Tensor]:
@@ -251,7 +250,7 @@ class StdDev(Stat):
     def init(self) -> None:
         self.var_stat = self._get_stat(Var(order=self.order))
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         pass
 
     def get(self) -> Optional[Tensor]:
@@ -276,7 +275,7 @@ class GeneralAccumFn(Stat):
     def get(self) -> Optional[Tensor]:
         return self.result
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         if self.result is None:
             self.result = x
         else:
@@ -308,6 +307,9 @@ class Sum(GeneralAccumFn):
         add_fn: Callable[[Tensor, Tensor], Tensor] = torch.add,
     ) -> None:
         super().__init__(name=name, fn=add_fn)
+
+    def update(self, x: Tensor, weight: float = 1) -> None:
+        super().update(x * weight)
 
 
 def CommonStats() -> List[Stat]:

--- a/captum/attr/_utils/summarizer.py
+++ b/captum/attr/_utils/summarizer.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import math
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 import torch
@@ -63,14 +64,25 @@ class Summarizer:
 
         return copy.deepcopy(self._stats)
 
-    def update(self, x: Union[float, Tensor, Tuple[Union[float, Tensor], ...]]) -> None:
+    def update(
+        self,
+        x: Union[float, Tensor, Tuple[Union[float, Tensor], ...]],
+        weight: float = 1,
+    ) -> None:
         r"""
         Calls `update` on each `Stat` object within the summarizer
 
         Args:
             x (Tensor or Tuple[Tensor, ...]):
                 The input(s) you wish to summarize
+            weight (float):
+                Frequency weight for this update. This is useful when ``x`` is
+                already a mean over multiple observations.
         """
+        if not math.isfinite(weight) or weight < 0:
+            raise ValueError(f"weight must be finite and nonnegative, got {weight}")
+        if weight == 0:
+            return
         if self._is_inputs_tuple is None:
             self._is_inputs_tuple = isinstance(x, tuple)
         else:
@@ -99,7 +111,7 @@ class Summarizer:
                 )
             if not isinstance(inp, torch.Tensor):
                 inp = torch.tensor(inp, dtype=torch.float)
-            self._summarizers[i].update(inp)
+            self._summarizers[i].update(inp, weight)
 
     @property
     def summary(
@@ -213,7 +225,7 @@ class SummarizerSingleTensor:
             stat._other_stats = self
             stat.init()
 
-    def update(self, x: Tensor) -> None:
+    def update(self, x: Tensor, weight: float = 1) -> None:
         r"""
         Updates the summary of a given tensor `x`
 
@@ -222,7 +234,10 @@ class SummarizerSingleTensor:
                 The tensor to summarize
         """
         for stat in self._stats:
-            stat.update(x)
+            if weight == 1:
+                stat.update(x)
+            else:
+                stat.update(x, weight)
 
     def get(self, stat: Stat) -> Optional[Stat]:
         r"""

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -56,6 +56,12 @@ class Test(BaseTest):
             (torch.tensor([-1.0]),), (torch.tensor([-2.0]),), method="gausslegendre"
         )
 
+        with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
+            _validate_input(
+                (torch.zeros((2, 3)),),
+                (torch.zeros((1, 4)),),
+            )
+
     def test_validate_nt_type(self) -> None:
         with self.assertRaises(
             AssertionError,

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -9,12 +9,33 @@
 
 import torch
 from captum.attr._core.noise_tunnel import SUPPORTED_NOISE_TUNNEL_TYPES
-from captum.attr._utils.common import _validate_input, _validate_noise_tunnel_type
+from captum.attr._utils.common import (
+    _tensorize_baseline,
+    _validate_input,
+    _validate_noise_tunnel_type,
+)
 from captum.testing.helpers import BaseTest
 
 
 # pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
+    def test_tensorize_scalar_baseline_preserves_value_dtype_and_layout(self) -> None:
+        integer_input = torch.tensor([[1, 2]])
+        integer_baseline = _tensorize_baseline((integer_input,), (0.5,))[0]
+        torch.testing.assert_close(integer_baseline, torch.tensor([[0.5, 0.5]]))
+
+        boolean_input = torch.tensor([[True, False]])
+        boolean_baseline = _tensorize_baseline((boolean_input,), (0,))[0]
+        self.assertEqual(boolean_baseline.dtype, torch.bool)
+
+        channels_last_input = torch.empty((2, 3, 4, 5)).to(
+            memory_format=torch.channels_last
+        )
+        channels_last_baseline = _tensorize_baseline((channels_last_input,), (0.5,))[0]
+        self.assertTrue(
+            channels_last_baseline.is_contiguous(memory_format=torch.channels_last)
+        )
+
     def test_validate_input(self) -> None:
         with self.assertRaises(AssertionError) as err:
             _validate_input(

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -167,6 +167,20 @@ class Test(BaseTest):
                 expected = inputs - baseline
                 torch.testing.assert_close(result, expected)
 
+    def test_inactive_nonfinite_baseline_does_not_contaminate_ablation(self) -> None:
+        inputs = torch.tensor([[1.0, 2.0]])
+        attribution = FeatureAblation(lambda values: values.sum(dim=1))
+
+        for inactive_value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(inactive_value=inactive_value):
+                result = attribution.attribute(
+                    inputs,
+                    baselines=torch.tensor([[0.0, inactive_value]]),
+                    feature_mask=torch.tensor([[0, 1]]),
+                )
+
+                self.assertEqual(result[0, 0].item(), 1.0)
+
     def test_simple_ablation_boolean(self) -> None:
         ablation_algo = FeatureAblation(BasicModelBoolInput())
         inp = torch.tensor([[True, False, True]])

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -77,6 +77,80 @@ class Test(BaseTest):
             ablation_algo, inp, [[80.0, 200.0, 120.0]], perturbations_per_eval=(1, 2, 3)
         )
 
+    def test_output_shape_validation_is_per_call(self) -> None:
+        ablation_algo = FeatureAblation(lambda x: x.sum())
+        inp = torch.tensor([[1.0, 2.0]])
+
+        ablation_algo.attribute(inp, perturbations_per_eval=1)
+
+        with self.assertRaisesRegex(AssertionError, "output shape"):
+            ablation_algo.attribute(inp, perturbations_per_eval=2)
+
+    def test_future_contributions_do_not_share_mutable_accumulators(self) -> None:
+        attribution = FeatureAblation(lambda x: x.sum())
+        barrier = threading.Barrier(2)
+        initial_attribution = [torch.zeros(1, 1)]
+        initial_weights = [torch.zeros(1, 1)]
+        initial_result = (
+            initial_attribution,
+            initial_weights,
+            torch.zeros(1),
+            torch.zeros(1),
+            1,
+            torch.float32,
+        )
+        initial_future: torch.futures.Future[Any] = torch.futures.Future()
+        initial_future.set_result(initial_result)
+
+        def process_contribution(**kwargs: Any) -> tuple[list[Tensor], list[Tensor]]:
+            total_attrib = kwargs["total_attrib"]
+            weights = kwargs["weights"]
+            snapshot = total_attrib[0].clone()
+            barrier.wait()
+            total_attrib[0] = snapshot + kwargs["modified_eval"].reshape_as(snapshot)
+            return total_attrib, weights
+
+        results: list[tuple[list[Tensor], list[Tensor]] | None] = [None, None]
+        errors: list[BaseException] = []
+
+        def evaluate(index: int, value: float) -> None:
+            modified_future: torch.futures.Future[Any] = torch.futures.Future()
+            modified_future.set_result(torch.tensor([value]))
+            collected_future: torch.futures.Future[Any] = torch.futures.Future()
+            collected_future.set_result([initial_future, modified_future])
+            try:
+                results[index] = attribution._eval_fut_to_ablated_out_fut_cross_tensor(
+                    collected_future,
+                    current_inputs=(torch.ones(1, 1),),
+                    current_mask=(torch.ones(1, 1, dtype=torch.bool),),
+                    perturbations_per_eval=1,
+                    num_examples=1,
+                )
+            except Exception as error:
+                errors.append(error)
+
+        with unittest.mock.patch.object(
+            attribution,
+            "_process_ablated_out_full",
+            side_effect=process_contribution,
+        ):
+            threads = [
+                threading.Thread(target=evaluate, args=(0, 1.0)),
+                threading.Thread(target=evaluate, args=(1, 2.0)),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(errors, [])
+        first_result = cast(tuple[list[Tensor], list[Tensor]], results[0])
+        second_result = cast(tuple[list[Tensor], list[Tensor]], results[1])
+        torch.testing.assert_close(
+            first_result[0][0] + second_result[0][0], torch.tensor([[3.0]])
+        )
+        torch.testing.assert_close(initial_attribution[0], torch.zeros(1, 1))
+
     def test_simple_ablation_int_to_int(self) -> None:
         ablation_algo = FeatureAblation(BasicModel())
         inp = torch.tensor([[-3, 1, 2]])

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -181,6 +181,20 @@ class Test(BaseTest):
 
                 self.assertEqual(result[0, 0].item(), 1.0)
 
+    def test_rejects_feature_mask_tuple_arity_mismatch(self) -> None:
+        inputs = (torch.tensor([[1.0]]), torch.tensor([[2.0]]))
+        attribution = FeatureAblation(lambda first, second: first[:, 0] + second[:, 0])
+
+        for feature_mask in (
+            (torch.tensor([[0]]),),
+            (torch.tensor([[0]]),) * 3,
+        ):
+            with self.subTest(mask_count=len(feature_mask)):
+                with self.assertRaisesRegex(
+                    AssertionError, "Input and feature mask must have the same"
+                ):
+                    attribution.attribute(inputs, feature_mask=feature_mask)
+
     def test_simple_ablation_boolean(self) -> None:
         ablation_algo = FeatureAblation(BasicModelBoolInput())
         inp = torch.tensor([[True, False, True]])

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -131,6 +131,42 @@ class Test(BaseTest):
             perturbations_per_eval=(1, 2, 3),
         )
 
+    def test_perturbation_methods_reject_baseline_tuple_arity_mismatch(self) -> None:
+        inputs = (torch.tensor([[1.0]]), torch.tensor([[2.0]]))
+        attribution = FeatureAblation(lambda first, second: first[:, 0] + second[:, 0])
+
+        for baselines in (
+            (torch.tensor([[0.0]]),),
+            (torch.tensor([[0.0]]),) * 3,
+        ):
+            with self.subTest(baseline_count=len(baselines)):
+                with self.assertRaisesRegex(
+                    AssertionError, "Input and baseline must have the same"
+                ):
+                    attribution.attribute(inputs, baselines=baselines)
+
+    def test_perturbation_methods_reject_invalid_baseline_batch_size(self) -> None:
+        inputs = torch.tensor([[1.0], [2.0], [3.0]])
+
+        attribution = FeatureAblation(lambda values: values[:, 0])
+        for baseline in (
+            torch.tensor([[10.0], [20.0]]),
+            torch.tensor([[10.0, 20.0]]),
+        ):
+            with self.subTest(baseline_shape=baseline.shape):
+                with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
+                    attribution.attribute(inputs, baselines=baseline)
+
+    def test_accepts_broadcastable_tensor_baselines(self) -> None:
+        inputs = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        attribution = FeatureAblation(lambda values: values.sum(dim=1))
+
+        for baseline in (torch.tensor([0.5, 1.5]), torch.tensor(0.5)):
+            with self.subTest(baseline_shape=baseline.shape):
+                result = attribution.attribute(inputs, baselines=baseline)
+                expected = inputs - baseline
+                torch.testing.assert_close(result, expected)
+
     def test_simple_ablation_boolean(self) -> None:
         ablation_algo = FeatureAblation(BasicModelBoolInput())
         inp = torch.tensor([[True, False, True]])

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -11,7 +11,12 @@ import unittest.mock
 from typing import Any, Callable, List, Tuple
 
 import torch
-from captum.attr._core.feature_permutation import _permute_feature, FeaturePermutation
+from captum.attr._core.feature_permutation import (
+    _generate_derangement,
+    _permute_feature,
+    _permute_feature_without_self_donors,
+    FeaturePermutation,
+)
 from captum.testing.helpers import BaseTest
 from captum.testing.helpers.basic import assertTensorAlmostEqual, set_all_random_seeds
 from captum.testing.helpers.basic_models import BasicModelWithSparseInputs
@@ -108,6 +113,59 @@ class Test(BaseTest):
                     result = _permute_feature(inp, mask)
 
                 self.assertEqual(result[1, 0].item(), 1.0)
+
+    def test_deranged_permutation_rejects_self_donors(self) -> None:
+        inp = torch.tensor([[1.0], [2.0], [3.0]])
+
+        with unittest.mock.patch(
+            "torch.randperm", return_value=torch.tensor([0, 1, 2])
+        ) as randperm:
+            result = _permute_feature_without_self_donors(inp, torch.tensor([True]))
+
+        self.assertEqual(randperm.call_count, 1)
+        torch.testing.assert_close(result, torch.tensor([[2.0], [3.0], [1.0]]))
+
+    def test_feature_permutation_exposes_no_self_donor_policy(self) -> None:
+        attribution = FeaturePermutation(
+            lambda inputs: inputs.sum(dim=1),
+            exclude_self_donors=True,
+        )
+
+        with unittest.mock.patch(
+            "torch.randperm", return_value=torch.tensor([0, 1, 2])
+        ):
+            result = attribution.perm_func(
+                torch.tensor([[1.0], [2.0], [3.0]]),
+                torch.tensor([True]),
+            )
+
+        torch.testing.assert_close(result, torch.tensor([[2.0], [3.0], [1.0]]))
+
+    def test_feature_permutation_rejects_conflicting_no_self_configuration(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "custom perm_func"):
+            FeaturePermutation(
+                lambda inputs: inputs.sum(dim=1),
+                perm_func=self._deterministic_perm,
+                exclude_self_donors=True,
+            )
+
+    def test_distinct_donor_can_have_equal_feature_value(self) -> None:
+        inp = torch.tensor([[1.0], [1.0]])
+
+        result = _permute_feature_without_self_donors(inp, torch.tensor([True]))
+
+        torch.testing.assert_close(result, inp)
+
+    @unittest.mock.patch("torch.randperm", return_value=torch.tensor([2, 1, 0]))
+    def test_derangement_uses_one_random_cycle(
+        self, mock_randperm: unittest.mock.MagicMock
+    ) -> None:
+        permutation = _generate_derangement(3)
+
+        torch.testing.assert_close(permutation, torch.tensor([2, 0, 1]))
+        self.assertEqual(mock_randperm.call_count, 1)
 
     def test_single_input(self) -> None:
         batch_size = 2

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -207,6 +207,128 @@ class Test(BaseTest):
 
         assertTensorAlmostEqual(self, attribs, expected, delta=1e-6, mode="max")
 
+    @unittest.mock.patch("torch.randperm", return_value=torch.tensor([1, 2, 0]))
+    def test_cross_tensor_group_uses_shared_donor_rows(
+        self, mock_randperm: unittest.mock.MagicMock
+    ) -> None:
+        forwarded_inputs = []
+
+        def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+            forwarded_inputs.append((x1.clone(), x2.clone()))
+            return x1[:, 0] * x2[:, 0]
+
+        inputs = (
+            torch.tensor([[1.0], [2.0], [3.0]]),
+            torch.tensor([[10.0], [20.0], [30.0]]),
+        )
+        feature_mask = (torch.tensor([[0]]), torch.tensor([[0]]))
+
+        FeaturePermutation(forward_func).attribute(inputs, feature_mask=feature_mask)
+
+        self.assertEqual(mock_randperm.call_count, 1)
+        torch.testing.assert_close(
+            forwarded_inputs[1][0], torch.tensor([[2.0], [3.0], [1.0]])
+        )
+        torch.testing.assert_close(
+            forwarded_inputs[1][1], torch.tensor([[20.0], [30.0], [10.0]])
+        )
+
+    def test_custom_cross_tensor_permutation_requires_grouped_function(self) -> None:
+        inputs = (torch.ones(2, 1), torch.ones(2, 1))
+        feature_mask = (torch.zeros(1, 1), torch.zeros(1, 1))
+        attribution = FeaturePermutation(
+            lambda first, second: first[:, 0] + second[:, 0],
+            perm_func=self._deterministic_perm,
+        )
+
+        with self.assertRaisesRegex(ValueError, "grouped_perm_func"):
+            attribution.attribute(inputs, feature_mask=feature_mask)
+
+    def test_cross_tensor_group_rejects_mismatched_batch_sizes(self) -> None:
+        inputs = (torch.ones(2, 1), torch.ones(3, 1))
+        feature_mask = (torch.zeros(1, 1), torch.zeros(1, 1))
+
+        with self.assertRaisesRegex(ValueError, "same batch size"):
+            FeaturePermutation(
+                lambda first, second: first[:, 0] + second[: first.shape[0], 0]
+            ).attribute(inputs, feature_mask=feature_mask)
+
+    def test_custom_grouped_permutation_is_applied_atomically(self) -> None:
+        forwarded_inputs = []
+
+        def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+            forwarded_inputs.append((x1.clone(), x2.clone()))
+            return x1[:, 0] * x2[:, 0]
+
+        def grouped_perm_func(
+            inputs: Tuple[Tensor, ...], masks: Tuple[Tensor, ...]
+        ) -> Tuple[Tensor, ...]:
+            return tuple(
+                torch.where(mask, input_tensor.flip(0), input_tensor)
+                for input_tensor, mask in zip(inputs, masks)
+            )
+
+        inputs = (
+            torch.tensor([[1.0], [2.0], [3.0]]),
+            torch.tensor([[10.0], [20.0], [30.0]]),
+        )
+        feature_mask = (torch.tensor([[0]]), torch.tensor([[0]]))
+        FeaturePermutation(
+            forward_func,
+            perm_func=self._deterministic_perm,
+            grouped_perm_func=grouped_perm_func,
+        ).attribute(inputs, feature_mask=feature_mask)
+
+        torch.testing.assert_close(
+            forwarded_inputs[1][0], torch.tensor([[3.0], [2.0], [1.0]])
+        )
+        torch.testing.assert_close(
+            forwarded_inputs[1][1], torch.tensor([[30.0], [20.0], [10.0]])
+        )
+
+    def test_custom_grouped_permutation_uses_perturbation_block_index(self) -> None:
+        forwarded_inputs = []
+
+        def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+            forwarded_inputs.append((x1.clone(), x2.clone()))
+            return (x1 + x2).sum(dim=1)
+
+        def grouped_perm_func(
+            inputs: Tuple[Tensor, ...], masks: Tuple[Tensor, ...]
+        ) -> Tuple[Tensor, ...]:
+            return tuple(
+                torch.where(mask, input_tensor.flip(0), input_tensor)
+                for input_tensor, mask in zip(inputs, masks)
+            )
+
+        inputs = (
+            torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            torch.tensor([[10.0, 20.0], [30.0, 40.0]]),
+        )
+        feature_mask = (
+            torch.tensor([[10, 20]]),
+            torch.tensor([[10, 20]]),
+        )
+
+        FeaturePermutation(
+            forward_func,
+            perm_func=self._deterministic_perm,
+            grouped_perm_func=grouped_perm_func,
+        ).attribute(
+            inputs,
+            feature_mask=feature_mask,
+            perturbations_per_eval=2,
+        )
+
+        torch.testing.assert_close(
+            forwarded_inputs[1][0],
+            torch.tensor([[3.0, 2.0], [1.0, 4.0], [1.0, 4.0], [3.0, 2.0]]),
+        )
+        torch.testing.assert_close(
+            forwarded_inputs[1][1],
+            torch.tensor([[30.0, 20.0], [10.0, 40.0], [10.0, 40.0], [30.0, 20.0]]),
+        )
+
     def test_n_samples_validation(self) -> None:
         def forward_func(x: Tensor) -> Tensor:
             return x.sum(dim=-1)
@@ -237,8 +359,12 @@ class Test(BaseTest):
         )
 
         feature_importance._min_examples_per_batch_grouped = 1
-        with self.assertRaises(AssertionError):
-            feature_importance.attribute(inp)
+        assertTensorAlmostEqual(
+            self,
+            feature_importance.attribute(inp),
+            torch.tensor([[0.0, 0.0]]),
+            delta=0.0,
+        )
 
     def test_simple_input_custom_mask_with_min_examples_in_group(self) -> None:
         def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
@@ -261,7 +387,7 @@ class Test(BaseTest):
         )
 
         feature_importance._min_examples_per_batch_grouped = 1
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "same batch size"):
             feature_importance.attribute(inp, feature_mask=mask)
 
     def _deterministic_perm(self, x: Tensor, feature_mask: Tensor) -> Tensor:
@@ -366,6 +492,88 @@ class Test(BaseTest):
         self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
         assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
         self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
+
+    def test_singleton_input_with_future_returns_zeros(self) -> None:
+        def forward_func(x: Tensor) -> Tensor:
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(
+            forward_func=self.construct_future_forward(forward_func)
+        )
+
+        attribs = feature_importance.attribute_future(torch.tensor([[1.0, 2.0]])).wait()
+
+        torch.testing.assert_close(attribs, torch.zeros((1, 2)))
+
+    def test_future_n_samples_and_run_forward_on_skip(self) -> None:
+        perm_calls = 0
+        forward_calls = 0
+
+        def perm_func(x: Tensor, feature_mask: Tensor) -> Tensor:
+            nonlocal perm_calls
+            perm_calls += 1
+            return torch.where(feature_mask.bool(), x.flip(0), x)
+
+        def forward_func(x: Tensor) -> Tensor:
+            nonlocal forward_calls
+            forward_calls += 1
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(
+            forward_func=self.construct_future_forward(forward_func),
+            perm_func=perm_func,
+        )
+        feature_importance.attribute_future(
+            torch.tensor([[1.0], [2.0]]), n_samples=3
+        ).wait()
+        self.assertEqual(perm_calls, 3)
+
+        skipped = FeaturePermutation(
+            forward_func=self.construct_future_forward(forward_func)
+        )
+        calls_before_skip = forward_calls
+        skipped.attribute_future(torch.tensor([[1.0]]), run_forward_on_skip=True).wait()
+        self.assertEqual(forward_calls - calls_before_skip, 2)
+
+    def test_future_run_forward_on_skip_isolates_alignment_error(self) -> None:
+        forward_calls = 0
+
+        def future_forward(x1: Tensor, x2: Tensor) -> torch.futures.Future[Tensor]:
+            nonlocal forward_calls
+            forward_calls += 1
+            future: torch.futures.Future[Any] = torch.futures.Future()
+            if forward_calls == 2:
+                future.set_exception(RuntimeError("alignment forward failed"))
+            else:
+                future.set_result(x2.sum(dim=-1))
+            return future
+
+        feature_importance = FeaturePermutation(
+            forward_func=future_forward,
+            perm_func=self._deterministic_perm,
+        )
+        inputs = (
+            torch.tensor([[1.0, 2.0]]),
+            torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        )
+        feature_mask = (
+            torch.tensor([[0, 0]]),
+            torch.tensor([[1, 2]]),
+        )
+
+        attributions = feature_importance.attribute_future(
+            inputs,
+            feature_mask=feature_mask,
+            run_forward_on_skip=True,
+        ).wait()
+
+        self.assertEqual(forward_calls, 4)
+        assertTensorAlmostEqual(
+            self,
+            attributions[0],
+            torch.zeros_like(attributions[0]),
+            delta=0.0,
+        )
 
     def test_multi_input(
         self,

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import unittest.mock
 from typing import Any, Callable, List, Tuple
 
 import torch
@@ -94,6 +95,19 @@ class Test(BaseTest):
             self.assertTrue(mask.shape == mask_size)
 
             self._check_perm_fn_with_mask(inp, mask)
+
+    def test_inactive_nonfinite_donor_does_not_contaminate_permutation(self) -> None:
+        mask = torch.tensor([False, True])
+
+        for inactive_value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(inactive_value=inactive_value):
+                inp = torch.tensor([[inactive_value, 2.0], [1.0, 3.0]])
+                with unittest.mock.patch(
+                    "torch.randperm", return_value=torch.tensor([1, 0])
+                ):
+                    result = _permute_feature(inp, mask)
+
+                self.assertEqual(result[1, 0].item(), 1.0)
 
     def test_single_input(self) -> None:
         batch_size = 2

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -115,6 +115,55 @@ class Test(BaseTest):
         self.assertEqual(result[3][0][0, 0].item(), 1.0)
         self.assertTrue(torch.isnan(result[3][0][0, 1]))
 
+    def test_rejects_feature_mask_tuple_arity_mismatch(self) -> None:
+        inputs = (torch.tensor([[1.0]]), torch.tensor([[2.0]]))
+        attribution = ShapleyValueSampling(
+            lambda first, second: first[:, 0] + second[:, 0]
+        )
+
+        for feature_mask in (
+            (torch.tensor([[0]]),),
+            (torch.tensor([[0]]),) * 3,
+        ):
+            with self.subTest(mask_count=len(feature_mask)):
+                for attribute in (
+                    attribution.attribute,
+                    attribution.attribute_future,
+                ):
+                    with self.assertRaisesRegex(
+                        AssertionError, "Input and feature mask must have the same"
+                    ):
+                        attribute(inputs, feature_mask=feature_mask)
+
+    def test_rejects_nonintegral_or_negative_feature_masks(self) -> None:
+        inputs = torch.tensor([[1.0, 2.0]])
+        attribution = ShapleyValueSampling(lambda values: values.sum(dim=1))
+
+        for feature_mask in (
+            torch.tensor([[0.0, 0.5]]),
+            torch.tensor([[0, -1]]),
+            torch.tensor([[0.0, float("nan")]]),
+            torch.tensor([[0.0, float("inf")]]),
+            torch.tensor([[0.0 + 0.0j, 1.0 + 0.0j]]),
+        ):
+            with self.subTest(feature_mask=feature_mask):
+                for attribute in (
+                    attribution.attribute,
+                    attribution.attribute_future,
+                ):
+                    with self.assertRaisesRegex(
+                        AssertionError, "non-negative integers"
+                    ):
+                        attribute(inputs, feature_mask=feature_mask)
+
+        for feature_mask in (
+            torch.tensor([[0.0, 1.0]]),
+            torch.tensor([[False, True]]),
+        ):
+            with self.subTest(valid_feature_mask=feature_mask):
+                result = attribution.attribute(inputs, feature_mask=feature_mask)
+                torch.testing.assert_close(result, inputs)
+
     @parameterized.expand([True, False])
     def test_simple_shapley_sampling(self, use_future: bool) -> None:
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -64,6 +64,57 @@ class Test(BaseTest):
                 with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
                     attribution.attribute_future(inputs, baselines=baseline)
 
+    def test_selected_nonfinite_baseline_is_replaced_cleanly(self) -> None:
+        attribution = ShapleyValueSampling(lambda values: values.sum(dim=1))
+
+        for selected_value in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(selected_value=selected_value):
+                result = attribution._update_current_tensors(
+                    (torch.tensor([[0.0, selected_value]]),),
+                    (torch.tensor([[1.0, 2.0]]),),
+                    1,
+                    (torch.tensor([[0, 1]]),),
+                    {1: [0]},
+                )
+
+                torch.testing.assert_close(result[0], torch.tensor([[0.0, 2.0]]))
+
+    def test_nonfinite_marginal_does_not_contaminate_other_features(self) -> None:
+        attribution = ShapleyValueSampling(lambda values: values.sum(dim=1))
+        previous_result: Future[
+            Tuple[Tensor, Tensor, torch.Size, List[Tensor], bool]
+        ] = Future()
+        previous_result.set_result(
+            (
+                torch.tensor([0.0]),
+                torch.tensor([0.0]),
+                torch.Size([1]),
+                [torch.zeros((1, 2))],
+                False,
+            )
+        )
+        modified_result: Future[Tensor] = Future()
+        modified_result.set_result(torch.tensor([1.0, float("nan")]))
+        evaluations: Future[
+            List[
+                Union[
+                    Future[Tuple[Tensor, Tensor, torch.Size, List[Tensor], bool]],
+                    Future[Tensor],
+                ]
+            ]
+        ] = Future()
+        evaluations.set_result([previous_result, modified_result])
+
+        result = attribution._eval_fut_to_prev_results_tuple(
+            evaluations,
+            1,
+            (torch.zeros((1, 2)),),
+            (torch.tensor([[[1, 0]], [[0, 1]]]),),
+        )
+
+        self.assertEqual(result[3][0][0, 0].item(), 1.0)
+        self.assertTrue(torch.isnan(result[3][0][0, 1]))
+
     @parameterized.expand([True, False])
     def test_simple_shapley_sampling(self, use_future: bool) -> None:
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -29,6 +29,41 @@ from torch.futures import Future
 
 
 class Test(BaseTest):
+    def test_rejects_baseline_tuple_arity_mismatch(self) -> None:
+        inputs = (torch.tensor([[1.0]]), torch.tensor([[2.0]]))
+        attribution = ShapleyValueSampling(
+            lambda first, second: first[:, 0] + second[:, 0]
+        )
+
+        for baselines in (
+            (torch.tensor([[0.0]]),),
+            (torch.tensor([[0.0]]),) * 3,
+        ):
+            with self.subTest(baseline_count=len(baselines)):
+                with self.assertRaisesRegex(
+                    AssertionError, "Input and baseline must have the same"
+                ):
+                    attribution.attribute(inputs, baselines=baselines)
+                with self.assertRaisesRegex(
+                    AssertionError, "Input and baseline must have the same"
+                ):
+                    attribution.attribute_future(inputs, baselines=baselines)
+
+    def test_rejects_invalid_baseline_shape(self) -> None:
+        inputs = torch.tensor([[1.0], [2.0], [3.0]])
+        attribution = ShapleyValueSampling(lambda values: values[:, 0])
+
+        for baseline in (
+            torch.tensor([[10.0], [20.0]]),
+            torch.tensor([[10.0, 20.0]]),
+            torch.tensor(10.0),
+        ):
+            with self.subTest(baseline_shape=baseline.shape):
+                with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
+                    attribution.attribute(inputs, baselines=baseline)
+                with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
+                    attribution.attribute_future(inputs, baselines=baseline)
+
     @parameterized.expand([True, False])
     def test_simple_shapley_sampling(self, use_future: bool) -> None:
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -64,6 +64,25 @@ class Test(BaseTest):
                 with self.assertRaisesRegex(AssertionError, "Baseline can be provided"):
                     attribution.attribute_future(inputs, baselines=baseline)
 
+    def test_float_scalar_baseline_preserves_dtype_for_integer_input(self) -> None:
+        inputs = torch.tensor([[1, 2]])
+        expected = torch.tensor([[0.5, 1.5]])
+
+        attribution = ShapleyValueSampling(lambda values: values.sum(dim=1))
+        result = attribution.attribute(inputs, baselines=0.5, n_samples=1)
+        torch.testing.assert_close(result, expected)
+
+        def future_sum(values: Tensor) -> Future[Tensor]:
+            result: Future[Tensor] = Future()
+            result.set_result(values.sum(dim=1))
+            return result
+
+        future_attribution = ShapleyValueSampling(future_sum)
+        future_result = future_attribution.attribute_future(
+            inputs, baselines=0.5, n_samples=1
+        ).wait()
+        torch.testing.assert_close(future_result, expected)
+
     def test_selected_nonfinite_baseline_is_replaced_cleanly(self) -> None:
         attribution = ShapleyValueSampling(lambda values: values.sum(dim=1))
 

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import math
 import random
 from typing import Callable, Generator, List, Union
 
@@ -30,6 +31,31 @@ def get_values(
 
 # pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
+    def test_weighted_updates_match_uneven_batches(self) -> None:
+        summarizer = Summarizer([Mean(), StdDev(order=0)])
+
+        summarizer.update(torch.tensor(1.0), weight=1)
+        summarizer.update(torch.tensor(3.0), weight=3)
+
+        summary = summarizer.summary
+        assert isinstance(summary, dict)
+        assertTensorAlmostEqual(self, summary["mean"], 2.5)
+        assertTensorAlmostEqual(self, summary["std_dev"], math.sqrt(0.75))
+
+    def test_weighted_updates_reject_invalid_weights(self) -> None:
+        for weight in (-1, float("inf"), float("nan")):
+            with self.subTest(weight=weight):
+                summarizer = Summarizer([Mean()])
+                with self.assertRaisesRegex(ValueError, "finite and nonnegative"):
+                    summarizer.update(torch.tensor(1.0), weight=weight)
+
+    def test_zero_weight_update_is_ignored(self) -> None:
+        summarizer = Summarizer([Mean()])
+
+        summarizer.update(torch.tensor(1.0), weight=0)
+
+        self.assertIsNone(summarizer.summary)
+
     def test_div0(self) -> None:
         summarizer = Summarizer([Var(), Mean()])
         summ = summarizer.summary


### PR DESCRIPTION
Summary:

Problem

- Async ablation mutated shared accumulators from completion callbacks.
- Output-shape validation leaked across calls.
- Async permutation ignored sampling and skipped-forward semantics.
- Cross-tensor feature groups could use incoherent donor rows.
- Permutation indices were created without the input device, and singleton batches could enter invalid or nonterminating paths.

Counterexamples

- Futures completing out of order could lose a contribution.
- Correlated tensors such as `(user_id, user_age)` could be sourced from different rows.
- A second call with a different output shape skipped validation.
- Batch size 1 could loop while searching for a non-identity permutation.
- Accelerator inputs could receive CPU permutation indices.

Fix

- Reduce async contributions independently and define zero-work results.
- Validate shape per call.
- Honor `n_samples` and `run_forward_on_skip` asynchronously.
- Share one donor mapping across a global feature group and require atomic grouped callbacks.
- Create permutation indices on the input device and make singleton permutation the identity.
- Add deterministic noncontiguous-ID and multi-block grouping coverage.
- Document and test that failures from async alignment-only forwards are isolated: PyTorch `Future.then` executes the continuation for failed futures, and the continuation intentionally does not read the failed value. This preserves completed attribution contributions.

Differential Revision: D117635564


