### PR TITLE
Point Captum's website lockfile at the public yarn registry

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6062,7 +6062,7 @@ q@^1.1.2:
 
 qs@>=6.15.2, qs@^6.4.0, qs@~6.14.0, qs@~6.5.2:
   version "6.15.2"
-  resolved "https://registry.facebook.net/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"


### PR DESCRIPTION
Summary:
Captum website lockfile exports publicly, but `qs` resolved from the internal registry, so public `yarn install` failed with `401 Unauthorized`. A prior manual fix regressed because `website/` lacked the OSS rewrite marker. This rewrites the URL and adds `.rewrite-lockfile.fb` so regeneration stays public. Internal installs still use Metaccio; ShipIt strips the marker. `github-export-checks` still requires a linked GitHub export PR.

Sentinel-Council-Run: council_1788382991_94df220a
Sentinel-Harness: claude

*Modify your team agent prompt, check stats, and leave feedback: https://www.internalfb.com/sentinel_agent/rotations/ai_platform_devx*
Model used: Claude Opus 5 (claude-opus-5[1m])

Differential Revision: D118536431


