### PR TITLE
Bump brace-expansion 1.1.12->1.1.18 in captum website (#1930)

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1627,9 +1627,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Summary:

Mirrors Dependabot PR meta-pytorch/captum#1929, bumping the transitive npm dependency `brace-expansion` from `1.1.12` to `1.1.18` in `fbcode/pytorch/captum/website/yarn.lock`.

This is a security patch (backport of the ReDoS fix, CVE-2026-13149 / GHSA-mh99-v99m-4gvg) on the maintenance-v1 line. `brace-expansion` is a transitive dependency of `minimatch@^1.1.7`; the range is unchanged, only the resolved version, tarball URL, and integrity hash are updated. The lockfile was regenerated with yarn (not hand-edited), preserving the `registry.yarnpkg.com` URL for OSS portability.

Differential Revision: D118809657


